### PR TITLE
add support for outputing json

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,9 +20,6 @@ module.exports = function(options){
           options: options
         };
         json = options.json;
-        if (json) {
-          console.log("output json!");
-        }
         t.tokens = LiveScript.tokens(t.input, {
           raw: options.lex
         });

--- a/src/index.ls
+++ b/src/index.ls
@@ -15,7 +15,6 @@ module.exports = (options || {}) ->
         input = file.contents.toString 'utf8'
         t = {input, options}
         json = options.json
-        console.log "output json!" if json
         t.tokens = LiveScript.tokens t.input, raw: options.lex
         t.ast = LiveScript.ast t.tokens
         options.bare ||= json


### PR DESCRIPTION
while gulp-livescript pass options to livescript such as "bare", LiveScript.compile doesn't support "json" option for json generation. The json generation feature is wrapped in command.js:CompileScript function inside LiveScript package as a command line option.

Yet sometimes we might need to compile livescript into json, so I adopt the code in command.js and patch gulp-livescript so that one can add an option "json" to generate json file from livescript, for example:

```
gulp.task 'json', ->
  gulp.src 'json/*.ls'
    .pipe gulp-plumber!
    .pipe gulp-livescript({+json,+bare}).on 'error', gutil.log
    .pipe gulp.dest "json/"
```
