### PR TITLE
Update to LiveScript 1.3.0 (package.json)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-livescript",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Compile LiveScript to JavaScript for Gulp",
   "main": "lib/index.js",
   "scripts": {
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/tomchentw/gulp-livescript",
   "dependencies": {
     "gulp-util": "*",
-    "LiveScript": "^1.2.0",
+    "LiveScript": "^1.3.0",
     "through2": "^0.5.1"
   },
   "devDependencies": {


### PR DESCRIPTION
``` bash
$ npm test

> gulp-livescript@1.3.0 test *****
> mocha -R spec --compilers ls:LiveScript --require should



  gulp-livescript
    ✓ should compile livescript file to javascript 
    ✓ should compile livescript with bare option to javascript 
    ✓ should compile livescript json files 
    ✓ should emit error when livescript compilation fails 
    ✓ should emit error with streaming files 


  5 passing (43ms)
```
