### PR TITLE
support json filename extension.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ gutil = require('gulp-util');
 module.exports = function(options){
   options || (options = {});
   function modifyLS(file, enc, done){
-    var error, input, t, json;
+    var error, fileExtension, input, t, json;
     if (file.isNull()) {
       return done(null, file);
     }
@@ -14,6 +14,7 @@ module.exports = function(options){
       error = "Streaming not supported";
     } else {
       try {
+        fileExtension = ".js";
         input = file.contents.toString("utf8");
         t = {
           input: input,
@@ -32,9 +33,10 @@ module.exports = function(options){
         if (json) {
           t.result = LiveScript.run(t.output, options, true);
           t.output = JSON.stringify(t.result, null, 2) + "\n";
+          fileExtension = ".json";
         }
         file.contents = new Buffer(t.output);
-        file.path = gutil.replaceExtension(file.path, ".js");
+        file.path = gutil.replaceExtension(file.path, fileExtension);
       } catch (e$) {
         error = e$;
       }

--- a/src/index.ls
+++ b/src/index.ls
@@ -12,6 +12,7 @@ module.exports = (options || {}) ->
       error = "Streaming not supported"
     else
       try
+        fileExtension = ".js"
         input = file.contents.toString "utf8"
         t = {input, options}
         json = options.json
@@ -23,8 +24,9 @@ module.exports = (options || {}) ->
         if json =>
           t.result = LiveScript.run t.output, options, true
           t.output = JSON.stringify(t.result, null, 2) + "\n"
+          fileExtension = ".json"
         file.contents = new Buffer t.output
-        file.path = gutil.replaceExtension file.path, ".js"
+        file.path = gutil.replaceExtension file.path, fileExtension
       catch error
 
     error = new gutil.PluginError "gulp-livescript", error if error


### PR DESCRIPTION
After generate json, the output filename extension was .js.

However, we might think the output filename extension is .json after compile livescript to json. So I change replaceExtension with json configuration.

```
gulp.task 'json', ->
  gulp.src 'json/*.ls'
    .pipe gulp-plumber!
    .pipe gulp-livescript({+json,+bare}).on 'error', gutil.log
    .pipe gulp.dest "json/"
```

It would output file with .json filename extension.
