### PR TITLE
Fix "LiveScript" dependency in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "__template__gist__": "https://gist.github.com/tomchentw/0dc24c30955c1a6c94d4#file-package-json",
   "name": "gulp-livescript",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Compile LiveScript to JavaScript for Gulp",
   "main": "lib/index.js",
   "scripts": {
@@ -39,7 +39,7 @@
     "through2": "^0.6.3"
   },
   "peerDependencies": {
-    "LiveScript": "^1.3.0"
+    "LiveScript": "~1.3.0"
   },
   "devDependencies": {
     "LiveScript": "^1.3.0",


### PR DESCRIPTION
Set dependency version to N.N.\* because LiveScript developers doesn't uses semver and brake backward compatibility in minor (instead of major) releases.

https://github.com/tomchentw/gulp-livescript/pull/13
