### PR TITLE
feat: shows filename on compilation error

### DIFF
--- a/src/index.ls
+++ b/src/index.ls
@@ -51,6 +51,7 @@ class VinylLSConverter
 
       clonedFile.contents = new Buffer(output)
     catch error
+      error.message += "\nat " + clonedFile.path
       clonedFile = null
     [error, clonedFile]
 

--- a/test/main.ls
+++ b/test/main.ls
@@ -91,7 +91,7 @@ it "should emit error when livescript compilation fails" !(done) ->
   ls.once "error" !(error) ->
     error.should.exist
     error.message.should.exist
-    error.message.should.equal "Parse error on line 1: Unexpected 'ID'"
+    error.message.should.equal "Parse error on line 1: Unexpected 'ID'\nat test/fixtures/illegal.js"
     done!
 
   ls.write fakeFile


### PR DESCRIPTION
#6 seems not work any more. And since we call LiveScript.tokens/ast alone for json, we have to append filename in plugin instead of using options in LiveScript.run.
